### PR TITLE
Changed shadow on the bar

### DIFF
--- a/app/views/pages/dashboard_mobile.html.erb
+++ b/app/views/pages/dashboard_mobile.html.erb
@@ -34,6 +34,9 @@
         <% @current_trip.trail.photo_url.nil? ? image_url = "https://media.timeout.com/images/105666541/750/562/image.jpg" : image_url = @current_trip.trail.photo_url %>
           <div style="background-image: linear-gradient(rgba(0,0,0,0.3),rgba(0,0,0,0.3)), url('<%= image_url %>'); height: 20vh; background-position: center; background-size: cover; background-repeat: no-repeat;">
           </div>
+              <div class="rounded d-flex justify-content-end align-items-end" style="background-image: url('<%= image_url %>'); height: 144px; width:100%; background-position: center; background-size: cover; background-repeat: no-repeat;">
+      <div class="badge badge-pill m-1 <% if trail.tag_list[0] === "easy"%>badge-success<% elsif trail.tag_list[0] === "medium"%>badge-warning<% else %>badge-danger<% end %>"><%= trail.tag_list[0] %></div>
+    </div>
           <div class="d-flex flex-column justify-content-end mobile-img-overlay">
             <div style="font-size: 1.5rem;"><%= link_to @current_trip.trail.name, user_trip_path(current_user, @current_trip), class:"text-white font-weight-bold", style:"text-decoration:none;" %></div>
             <div class="text-white"><%= @current_trip.trail.location %></div>

--- a/app/views/trails/index.html.erb
+++ b/app/views/trails/index.html.erb
@@ -1,7 +1,7 @@
 <div class="container-fluid p-0" style="background-color: white; max-width:97vw;">
   <div class="row" style="background-color: white;">
         <form class="col-sm-12 col-lg-4" style="margin-top: 7.5rem;" action="<%= new_trip_path(@trip) %>">
-          <div class="mb-4 pt-3" style="background-color: white; position: fixed; top: 7vh; left: 0; z-index: 2; width:33.3333%; box-shadow: 2px 2px 10px 4px rgba(111,111,111,0.4)">
+          <div class="mb-4 pt-3" style="background-color: white; position: fixed; top: 7vh; left: 0; z-index: 2; width:33.3333%; box-shadow: rgba(0, 0, 0, 0.1) 0px 10px 15px -3px, rgba(0, 0, 0, 0.05) 0px 4px 6px -2px;">
             <h2 class="text-center font-weight-bold"><%= @trails.length %> trails <%= @trails.length > 0 ? params[:location] && params[:location] != "" ? "in " + params[:location].titlecase : "in the world" : "found" %></h2>
             <p class="text-center">Explore and find your next hike from the trails below</p>
           </div>


### PR DESCRIPTION
Note: It was bugging me that the bar showing number of trails based on search was not sized to the rest of the col on mobile. Was unable to fix this because if you set a % to the bar, it will always follow the parent container which has the default bootstrap col class. Also cannot remove the padding on the sides, which affects the box shadow that appears. Changed to box shadow on bottom only

To fix after the bootcamp